### PR TITLE
Potential fix for code scanning alert no. 1: Size computation for allocation may overflow

### DIFF
--- a/internal/pkg/danger/buf.go
+++ b/internal/pkg/danger/buf.go
@@ -33,7 +33,11 @@ func (b *Buf) Reset() {
 }
 
 func (b *Buf) grow(n int) {
-	buf := make([]byte, len(b.buf), 2*cap(b.buf)+n)
+	newCap := 2*cap(b.buf) + n
+	if newCap < 0 {
+		panic("danger.Buf.grow: size computation overflow")
+	}
+	buf := make([]byte, len(b.buf), newCap)
 	copy(buf, b.buf)
 	b.buf = buf
 }


### PR DESCRIPTION
Potential fix for [https://github.com/slowedcodinganai/fleet-server/security/code-scanning/1](https://github.com/slowedcodinganai/fleet-server/security/code-scanning/1)

To fix the problem, we need to ensure that the size computation for the allocation does not overflow. This can be achieved by adding a guard to check if the computed size exceeds the maximum value for an `int`. If it does, we should handle the error appropriately, such as by returning an error or panicking with a descriptive message.

The best way to fix this without changing existing functionality is to add a check in the `grow` function to ensure that `2*cap(b.buf) + n` does not exceed the maximum value for an `int`. If it does, we should panic with an appropriate error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
